### PR TITLE
update 'wait in between API calls' section

### DIFF
--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "id": "b456baeb-fe51-45c8-940e-7f6ec52da0df",
    "metadata": {},
    "outputs": [],
@@ -290,7 +290,7 @@
     "    temperature=0.5,\n",
     "    max_tokens=200,\n",
     "    timeout=60,\n",
-    "    max_retries=2,\n",
+    "    max_retries=10,\n",
     "    # organization=\"...\",\n",
     "    # model=\"gpt-35-turbo\",\n",
     "    # model_version=\"0125\",\n",
@@ -897,7 +897,9 @@
    "source": [
     "Depending on the users Azure plan and account will determine how many API requests can be made within a given interval. If too many requests are sent frequently an error may occur where the user will be told to wait **x** amount of time before sending another request.\n",
     "\n",
-    "To ensure this doesn't happen and the user is not overwhelming the Azure services, make sure to wait between API calls when possible, this can be enforced by using the `time` package."
+    "When creating a model, one of the parameters briefly mentioned earlier was the `max_retries` parameter. When calling the underlying Python OpenAI library, the library will wait and retry the call on your behalf at least 2 times (the default) before raising a RateLimiteError, or whatever `max retries` is set as.\n",
+    "\n",
+    "Otherwise, to ensure the user is not overwhelming the Azure services, make sure to wait between API calls when possible - this can be enforced by using the `time` package."
    ]
   },
   {


### PR DESCRIPTION
Added a brief section to the 'wait in between API calls' section to reiterate how the max_retries parameter works. I also updated the model to now attempt 10 retries before throwing an error.